### PR TITLE
Fix typo in var name in ILR update script

### DIFF
--- a/resources/publish_to_ilr.sh
+++ b/resources/publish_to_ilr.sh
@@ -141,7 +141,7 @@ else
 fi
 
 
-if [ "$DOSUERS" = true ]; then
+if [ "$DOUSERS" = true ]; then
     UFLAG="true"
     UVAL="1"
 else 


### PR DESCRIPTION
DOSUERS -> DOUSERS

This config var is ignored by the script because of the typo.